### PR TITLE
Release version 0.0.6 with compressing dir in config actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ When uploading a template version you can use the following keys (`uploadReadmeF
 |:-----------------|:-----------------|
 | **uploadVersionName** | Semantic version name |
 | **uploadReadmeFile** | Optional path to README file to upload |
-| **uploadTemplateFile** | TOSCA YAML service template file or compressed TOSCA Cloud Service Archive (CSAR) |
+| **uploadTemplateFile** | TOSCA YAML service template file, compressed TOSCA Cloud Service Archive (CSAR) or directory to be compressed |
 
 Example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "template-library-plugin",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "template-library-plugin",
 	"description": "This is a VS Code/RADON IDE extension for Template library publishing service.",
 	"publisher": "radon",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"engines": {
 		"vscode": "^1.49.0"
 	},


### PR DESCRIPTION
Compressing directory for template file is now possible also with config actions - before it was only a part of interactive actions. 
User  can input a path to directory to JSON file as `uploadTemplateFile` to be compressed into template file (.zip).